### PR TITLE
Added timer functionality and a game over screen

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="DesignSurface">
+    <option name="filePathToZoomLevelMap">
+      <map>
+        <entry key="..\:/Users/carte/School/2022 Winter/CS2063/Reflex Revolution/reflex-revolution/app/src/main/res/layout/activity_main.xml" value="0.1793478260869565" />
+        <entry key="..\:/Users/carte/School/2022 Winter/CS2063/Reflex Revolution/reflex-revolution/app/src/main/res/layout/game_over.xml" value="0.176" />
+        <entry key="..\:/Users/carte/School/2022 Winter/CS2063/Reflex Revolution/reflex-revolution/app/src/main/res/layout/timer_test.xml" value="0.25" />
+      </map>
+    </option>
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,12 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".TimerTestActivity">
+        </activity>
+        <activity
+            android:name=".GameOverActivity">
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/ca/unb/mobiledev/reflexrevolution/GameOverActivity.java
+++ b/app/src/main/java/ca/unb/mobiledev/reflexrevolution/GameOverActivity.java
@@ -1,0 +1,51 @@
+package ca.unb.mobiledev.reflexrevolution;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+public class GameOverActivity extends AppCompatActivity {
+
+    private TextView scoreText;
+    private Button replayButton;
+    private Button menuButton;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.game_over);
+
+        scoreText = findViewById(R.id.scoreText);
+        replayButton = findViewById(R.id.replayButton);
+        menuButton = findViewById(R.id.menuButton);
+
+        //Retrieve score
+        Bundle extras = getIntent().getExtras();
+        if(extras != null){
+            scoreText.setText("Score: " + extras.getInt("Score"));
+        }
+
+        //Start activity for new game if "Play Again" is hit
+        replayButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent intent = new Intent(GameOverActivity.this, TimerTestActivity.class);
+                startActivity(intent);
+                finish();
+            }
+        });
+
+        //Close this activity if "Menu" button is hit, returning to menu
+        menuButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                finish();
+            }
+        });
+    }
+}

--- a/app/src/main/java/ca/unb/mobiledev/reflexrevolution/MainActivity.java
+++ b/app/src/main/java/ca/unb/mobiledev/reflexrevolution/MainActivity.java
@@ -2,13 +2,28 @@ package ca.unb.mobiledev.reflexrevolution;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.Button;
 
 public class MainActivity extends AppCompatActivity {
+
+    private Button startButton;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        startButton = findViewById(R.id.startButton);
+        startButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent intent = new Intent(MainActivity.this, TimerTestActivity.class);
+                startActivity(intent);
+            }
+        });
     }
 }

--- a/app/src/main/java/ca/unb/mobiledev/reflexrevolution/TimerTestActivity.java
+++ b/app/src/main/java/ca/unb/mobiledev/reflexrevolution/TimerTestActivity.java
@@ -1,0 +1,79 @@
+package ca.unb.mobiledev.reflexrevolution;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.CountDownTimer;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+public class TimerTestActivity extends AppCompatActivity {
+
+    private Button resetButton;
+    private TextView testText;
+    private TextView resetText;
+    private CountDownTimer timer;
+    private int timeCount;
+    private int resetCount;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.timer_test);
+
+        testText = findViewById(R.id.timerText);
+        resetText = findViewById(R.id.resetText);
+        resetButton = findViewById(R.id.resetButton);
+        resetCount = 0;
+
+        updateResetText();
+        newTimer();
+
+        resetButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                resetTimer();
+            }
+        });
+    }
+
+    private void updateTimerText(){
+        testText.setText("Timer: " + timeCount);
+
+    }
+
+    private void updateResetText(){
+        resetText.setText("Resets: " + resetCount);
+    }
+
+    private void resetTimer(){
+        timer.cancel();
+        resetCount++;
+        updateResetText();
+        newTimer();
+    }
+
+    //create a new timer that counts down from 5, and closes the activity once it hits 0
+    private void newTimer(){
+        timeCount = 5;
+        timer = new CountDownTimer(5000, 1000) {
+            @Override
+            //onTick() is also called as soon as the counter starts, so call timeCount-- after updateText()
+            public void onTick(long l) {
+                updateTimerText();
+                timeCount--;
+            }
+
+            @Override
+            //When timer hits zero, start GameOverActivity and pass it the "score"
+            public void onFinish() {
+                Intent intent = new Intent(TimerTestActivity.this, GameOverActivity.class);
+                intent.putExtra("Score", resetCount);
+                startActivity(intent);
+                finish();
+            }
+        }.start();
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,13 +6,14 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <TextView
+    <Button
+        android:id="@+id/startButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Hello World!"
+        android:text="Start"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/game_over.xml
+++ b/app/src/main/res/layout/game_over.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Button
+        android:id="@+id/replayButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="26dp"
+        android:text="Play Again"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/scoreText" />
+
+    <Button
+        android:id="@+id/menuButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="46dp"
+        android:text="Menu"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/replayButton" />
+
+    <TextView
+        android:id="@+id/scoreText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Score:"
+        android:textAlignment="center"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toTopOf="@+id/replayButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.498"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_begin="20dp" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline3"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_begin="20dp" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/timer_test.xml
+++ b/app/src/main/res/layout/timer_test.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:id="@+id/linearLayout"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginStart="1dp"
+        android:layout_marginTop="1dp"
+        android:layout_marginEnd="1dp"
+        android:layout_marginBottom="1dp"
+        android:orientation="vertical"
+        android:gravity="center"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/resetText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Resets:"
+            android:textAlignment="center"
+            android:textSize="20sp" />
+
+        <TextView
+            android:id="@+id/timerText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Timer:"
+            android:textAlignment="center"
+            android:textSize="20sp" />
+
+        <Button
+            android:id="@+id/resetButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Reset" />
+
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Added a timer that counts down, and can be reset by a button. When the timer hits 0, the game over activity pops up. This activity reports the score, and gives option to play again or return to menu.

Note: One time I pressed "reset" the instant the timer ran out, and it popped up the game over screen, but when I replayed, the game over screen popped up again when the count timer had not yet hit zero. I replayed again, and the same thing happened. I was not able to reproduce this after ending and starting the app again, but just keep in the back of our heads that this may happen again.